### PR TITLE
feat: Initialize Gradle project and core modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,133 @@
-# Compiled class file
-*.class
+# Gradle
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
 
-# Log file
+# IntelliJ
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# macOS
+.DS_Store
+
+# Kotlin
+*.class
+*.jar
+*.kdoc
+*.war
+*.ear
+
+# Logs
+logs
 *.log
 
-# BlueJ files
-*.ctxt
+# Other
+*.swp
+*~
+target/
+out/
 
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
+# Specific to Gradle Kotlin DSL
+.gradle.kts.swp
+.gradle.kts.swp.lock
+.gradle.kts.lockfile
+.gradle.kts.state
+*.kts~
+*.gradle.kts~
+.gradle.kts.cache/
+.gradle-format-cache/
 
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
+# Compiled Kotlin classes
+*.kt.jar
+*.kt.bin
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*
+# Build cache
+.build-cache/
 
-# Kotlin Gradle plugin data, see https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects
-.kotlin/
+# Gradle daemon logs
+.gradle-daemon/
+
+# Gradle report files
+build/reports/
+
+# Kotlin compiler cache
+.kotlin-compiler-cache/
+kotlin-compiler-cache/
+
+# Generated files from annotation processors
+build/generated/
+
+# Android Studio files (if applicable, good to have)
+.idea/libraries/
+.idea/misc.xml
+.idea/modules.xml
+.idea/runConfigurations/
+.idea/vcs.xml
+.idea/workspace.xml
+local.properties
+*.apk
+*.aab
+*.ap_
+*.dex
+build/intermediates/
+build/outputs/
+captures/
+.cxx/
+*.hprof
+
+# Sensitive files
+*.keystore
+*.jks
+*.private
+*.secret
+secrets/
+sensitive/
+
+# VS Code
+.vscode/
+
+# Eclipse
+.classpath
+.project
+.settings/
+
+# NetBeans
+nbproject/private/
+build/classes/
+dist/
+nbbuild/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+
+# Maven - if you ever use Maven wrapper or import Maven projects
+.mvn/
+mvnw
+mvnw.cmd
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.m2/
+
+# Node.js / npm / yarn - if you have frontend parts
+node_modules/
+npm-debug.log
+yarn-error.log
+yarn.lock
+package-lock.json
+coverage/
+dist/
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    kotlin("jvm") version "1.9.22"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+}

--- a/lumos-examples/build.gradle.kts
+++ b/lumos-examples/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    kotlin("jvm") version "1.9.22"
+    application
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    // Dependencies on lumos-plugin and lumos-runtime will be added later
+}
+
+application {
+    mainClass.set("com.lumos.examples.MainKt") // Example main class
+}

--- a/lumos-plugin/build.gradle.kts
+++ b/lumos-plugin/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    kotlin("jvm") version "1.9.22"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    // For compiler plugins
+    compileOnly(kotlin("compiler-embeddable")) // Or kotlin("compiler")
+    // K2/FIR specific artifacts - placeholder, might need to be adjusted
+    // compileOnly("org.jetbrains.kotlin:kotlin-fir-compiler-plugin-api:1.9.22") // Example, verify correct artifact
+}
+
+// Optional: Configure Kotlin compilation options if needed
+// tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+//     kotlinOptions {
+//         jvmTarget = "1.8"
+//     }
+// }

--- a/lumos-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+++ b/lumos-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -1,0 +1,1 @@
+com.jgarcia.lumos.LumosCompilerPluginRegistrar

--- a/lumos-runtime/build.gradle.kts
+++ b/lumos-runtime/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    kotlin("jvm") version "1.9.22"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,5 @@
+rootProject.name = "kotlin-gradle-project"
+
+includeBuild("lumos-plugin")
+includeBuild("lumos-runtime")
+includeBuild("lumos-examples")


### PR DESCRIPTION
I've set up the root Gradle project with Kotlin DSL. I've also created the following modules:
- lumos-plugin: For the K2 compiler plugin.
- lumos-runtime: For runtime components like the Lumen data class.
- lumos-examples: For sample usage and manual testing.

The CompilerPluginRegistrar FQN in lumos-plugin has been set to com.jgarcia.lumos.LumosCompilerPluginRegistrar.