### PR TITLE
WIP: Story 1.5 - FQN Propagation Fix & Test Setup

### DIFF
--- a/lumos-examples/build.gradle.kts
+++ b/lumos-examples/build.gradle.kts
@@ -9,9 +9,18 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
+    implementation(project(":lumos-runtime"))
+    kotlinCompilerPluginClasspath(project(":lumos-plugin"))
     // Dependencies on lumos-plugin and lumos-runtime will be added later
 }
 
 application {
     mainClass.set("com.lumos.examples.MainKt") // Example main class
+}
+
+lumos {
+    targetMethodSignatures.set(listOf(
+        "com.example.KotlinExample.targetMethodInKotlin(java.lang.String)",
+        "com.example.JavaExample.targetMethodInJava(int)"
+    ))
 }

--- a/lumos-examples/src/main/java/com/example/JavaExample.java
+++ b/lumos-examples/src/main/java/com/example/JavaExample.java
@@ -1,0 +1,17 @@
+package com.example;
+
+// Assuming com.lumos.runtime.Lumen is the data class that will be injected.
+// If the package or class name is different, please adjust.
+import com.lumos.runtime.Lumen; // Ensure this import is correct
+
+public class JavaExample {
+    public void targetMethodInJava(Lumen lumen, int value) {
+        System.out.println("JavaExample.targetMethodInJava called:");
+        System.out.println("  Value: " + value);
+        System.out.println("  Lumen filePath: " + lumen.getFilePath());
+        System.out.println("  Lumen fileName: " + lumen.getFileName());
+        System.out.println("  Lumen lineNumber: " + lumen.getLineNumber());
+        System.out.println("  Lumen targetFunctionName: " + lumen.getTargetFunctionName());
+        // Add other Lumen fields if they exist and are relevant for MVP
+    }
+}

--- a/lumos-examples/src/main/kotlin/com/example/KotlinExample.kt
+++ b/lumos-examples/src/main/kotlin/com/example/KotlinExample.kt
@@ -1,0 +1,17 @@
+package com.example
+
+// Assuming com.lumos.runtime.Lumen is the data class that will be injected.
+// If the package or class name is different, please adjust.
+import com.lumos.runtime.Lumen // Ensure this import is correct
+
+class KotlinExample {
+    fun targetMethodInKotlin(lumen: Lumen, name: String) {
+        println("KotlinExample.targetMethodInKotlin called:")
+        println("  Name: " + name)
+        println("  Lumen filePath: " + lumen.filePath)
+        println("  Lumen fileName: " + lumen.fileName)
+        println("  Lumen lineNumber: " + lumen.lineNumber)
+        println("  Lumen targetFunctionName: " + lumen.targetFunctionName)
+        // Add other Lumen fields if they exist and are relevant for MVP
+    }
+}

--- a/lumos-examples/src/main/kotlin/com/example/Main.kt
+++ b/lumos-examples/src/main/kotlin/com/example/Main.kt
@@ -1,0 +1,15 @@
+package com.example
+
+fun main() {
+    println("Starting Lumos example application...")
+
+    val kotlinExample = KotlinExample()
+    println("\nCalling Kotlin target method...")
+    kotlinExample.targetMethodInKotlin("Test Kotlin Call") // Plugin should inject Lumen
+
+    println("\nCalling Java target method...")
+    val javaExample = JavaExample()
+    javaExample.targetMethodInJava(123) // Plugin should inject Lumen
+
+    println("\nLumos example application finished.")
+}

--- a/lumos-plugin/src/main/kotlin/com/lumos/gradle/LumosGradleSubplugin.kt
+++ b/lumos-plugin/src/main/kotlin/com/lumos/gradle/LumosGradleSubplugin.kt
@@ -1,0 +1,90 @@
+package com.lumos.gradle
+
+import com.lumos.plugin.LumosCliOptions
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
+import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
+import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
+
+/**
+ * Gradle subplugin for Lumos.
+ * This class integrates the Lumos compiler plugin with the Kotlin Gradle plugin.
+ * It is responsible for:
+ * 1. Registering the `LumosGradleExtension` to allow users to configure the plugin
+ *    via their `build.gradle.kts` files.
+ * 2. Passing the configured settings (e.g., target FQNs) to the Kotlin compiler
+ *    as command-line options.
+ *
+ * This class is discovered via service loading (see META-INF/services).
+ */
+class LumosGradleSubplugin : KotlinCompilerPluginSupportPlugin {
+
+    override fun apply(project: Project) {
+        // Register the LumosGradleExtension with the project, making it available
+        // for configuration in build scripts (e.g., lumos { ... }).
+        project.extensions.create(LumosCliOptions.PLUGIN_DISPLAY_NAME.lowercase(), LumosGradleExtension::class.java)
+    }
+
+    /**
+     * Checks if the Lumos plugin is applicable to the given Kotlin compilation.
+     * For now, it's considered applicable to all Kotlin compilations.
+     *
+     * @param kotlinCompilation The Kotlin compilation context.
+     * @return True if the plugin should be applied, false otherwise.
+     */
+    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
+
+    /**
+     * Provides the unique identifier for the Lumos compiler plugin.
+     * This must match the ID used by the `CompilerPluginRegistrar`.
+     *
+     * @return The compiler plugin ID.
+     */
+    override fun getCompilerPluginId(): String = LumosCliOptions.PLUGIN_ID
+
+    /**
+     * Specifies the Maven artifact coordinates for the Lumos compiler plugin.
+     * This tells the Kotlin Gradle plugin where to find the actual plugin JAR.
+     * It assumes the plugin is published with the group and version of the current project.
+     *
+     * @return A [SubpluginArtifact] pointing to the Lumos plugin.
+     */
+    override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
+        groupId = "com.lumos", // Assuming this is the group ID, adjust if different
+        artifactId = "lumos-plugin", // Name of the plugin module
+        version = "0.1.0-SNAPSHOT" // Placeholder version, adjust or read from project.version
+        // Consider using project.group and project.version for dynamic values if this plugin
+        // is part of the same Gradle build as the project it's applied to,
+        // or use fixed published coordinates.
+    )
+
+    /**
+     * Applies the plugin's configuration to the given Kotlin compilation.
+     * This method reads settings from the [LumosGradleExtension] and translates them
+     * into [SubpluginOption] instances that are passed to the Kotlin compiler.
+     *
+     * @param kotlinCompilation The Kotlin compilation to configure.
+     * @return A [Provider] of a list of [SubpluginOption]s for the compiler.
+     */
+    override fun applyToCompilation(
+        kotlinCompilation: KotlinCompilation<*>
+    ): Provider<List<SubpluginOption>> {
+        val project = kotlinCompilation.target.project
+        val lumosExtension = project.extensions.findByType(LumosGradleExtension::class.java)
+            ?: LumosGradleExtension() // Provide a default if not configured
+
+        return project.provider {
+            val options = mutableListOf<SubpluginOption>()
+
+            // Get the FQNs from the extension. If null or empty, this will be an empty list.
+            val targetFqns = lumosExtension.targetMethodSignatures.getOrElse(emptyList())
+
+            for (fqn in targetFqns) {
+                options.add(SubpluginOption(key = LumosCliOptions.FQN_OPTION.optionName, value = fqn))
+            }
+            options
+        }
+    }
+}

--- a/lumos-plugin/src/main/kotlin/com/lumos/plugin/LumosCliOptions.kt
+++ b/lumos-plugin/src/main/kotlin/com/lumos/plugin/LumosCliOptions.kt
@@ -1,0 +1,34 @@
+package com.lumos.plugin
+
+import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
+
+/**
+ * Defines the command-line interface options for the Lumos compiler plugin.
+ * These options are used to pass configuration from Gradle (or other build systems)
+ * to the compiler plugin during the compilation process.
+ */
+object LumosCliOptions {
+
+    /**
+     * Command-line option to specify a fully qualified name (FQN) of a method
+     * to be targeted by the Lumos plugin.
+     * This option can be provided multiple times for multiple targets.
+     *
+     * Syntax: -P plugin:com.lumos.plugin:fqn=<the.method.Fqn>
+     */
+    val FQN_OPTION: AbstractCliOption = object : AbstractCliOption(
+        optionName = "fqn",
+        valueDescription = "<fully.qualified.name>",
+        description = "Fully qualified name of a method to target",
+        required = false,
+        allowMultipleOccurrences = true
+    ) {}
+
+    // Array of all options provided by the Lumos plugin.
+    // This is typically used by the CompilerPluginRegistrar.
+    val ALL_OPTIONS: Array<AbstractCliOption> = arrayOf(FQN_OPTION)
+
+    // Constants for plugin ID and name, useful for the Gradle subplugin.
+    const val PLUGIN_ID: String = "com.lumos.plugin"
+    const val PLUGIN_DISPLAY_NAME: String = "Lumos"
+}

--- a/lumos-plugin/src/main/kotlin/com/lumos/plugin/LumosCompilerPluginRegistrar.kt
+++ b/lumos-plugin/src/main/kotlin/com/lumos/plugin/LumosCompilerPluginRegistrar.kt
@@ -1,44 +1,35 @@
 package com.lumos.plugin
 
 import com.lumos.fir.LumosFirExtensionRegistrar
+import com.lumos.fqn.FqnParser // Added import
+import com.lumos.fqn.ParsedFqnData // Added import
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 
-/**
- * The main entry point for the Lumos compiler plugin.
- * This class is responsible for registering the necessary components with the Kotlin compiler,
- * particularly for the K2 compiler pipeline (FIR).
- *
- * It is registered as a service in
- * `META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar`.
- */
 @OptIn(ExperimentalCompilerApi::class)
 class LumosCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
-    /**
-     * Registers compiler extensions into the provided [ExtensionStorage].
-     * This method is called by the Kotlin compiler to allow plugins to integrate
-     * their custom logic.
-     *
-     * For the Lumos plugin, this method initializes and registers the [LumosFirExtensionRegistrar].
-     * Currently, it passes an empty list of target FQNs to the [LumosFirExtensionRegistrar].
-     * In a future implementation, this list will be populated from the settings provided
-     * by the [com.lumos.gradle.LumosGradleExtension].
-     *
-     * @param configuration The current compiler configuration, which might be used to
-     *                      retrieve plugin-specific settings in more advanced scenarios.
-     */
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
-        // Pass an empty list of FQNs for now.
-        // This list will eventually be populated from the Gradle extension.
-        FirExtensionRegistrar.registerExtension(LumosFirExtensionRegistrar(emptyList()))
+        // Retrieve the FQN strings passed as command line options
+        val fqnStrings = configuration.get(LumosCliOptions.FQN_OPTION) ?: emptyList()
+
+        val fqnParser = FqnParser() // Instantiate FqnParser
+        val parsedFqns = fqnStrings.mapNotNull { fqnString ->
+            try {
+                fqnParser.parse(fqnString)
+            } catch (e: IllegalArgumentException) {
+                // Optionally, report a warning/error to the user via MessageCollector
+                // For now, just return null to filter it out
+                // configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY)?.report(...)
+                null
+            }
+        }
+
+        // Pass the parsed FQNs to the FirExtensionRegistrar
+        FirExtensionRegistrar.registerExtension(LumosFirExtensionRegistrar(parsedFqns))
     }
 
-    /**
-     * Indicates whether this compiler plugin registrar supports the K2 compiler frontend (FIR).
-     * For Lumos, this is set to `true` as it targets the K2 pipeline.
-     */
     override val supportsK2: Boolean
         get() = true
 }

--- a/lumos-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
+++ b/lumos-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
@@ -1,0 +1,1 @@
+com.lumos.gradle.LumosGradleSubplugin

--- a/lumos-tests/build.gradle.kts
+++ b/lumos-tests/build.gradle.kts
@@ -14,6 +14,11 @@ dependencies {
     implementation(kotlin("stdlib"))
     testImplementation(kotlin("test")) // For writing tests (e.g., JUnit or KotlinTest)
 
+    // Added dependencies for Lumos testing
+    testImplementation("com.github.tschuchortdev:kotlin-compile-testing:1.5.0")
+    testImplementation(project(":lumos-plugin"))
+    testImplementation(project(":lumos-runtime"))
+
     // Dependencies on kotlin-compile-testing, lumos-plugin, and lumos-runtime
     // will be added later after local publishing setup or when specific versions are known.
     // For example:

--- a/lumos-tests/src/test/kotlin/com/lumos/tests/LumosKotlinCompileTest.kt
+++ b/lumos-tests/src/test/kotlin/com/lumos/tests/LumosKotlinCompileTest.kt
@@ -1,0 +1,87 @@
+package com.lumos.tests
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+@OptIn(ExperimentalCompilerApi::class)
+class LumosKotlinCompileTest {
+
+    // Companion object to hold utility methods or shared state for tests
+    companion object {
+        // This list could be used to capture Lumen data from within compiled test code
+        // by having the test code add strings to it.
+        val capturedLumenData = mutableListOf<String>()
+
+        // Method that can be called from compiled test code to record Lumen details.
+        // Ensure this method is public and static (or in a companion object) to be callable.
+        @JvmStatic // Important for Java interop if called from Java compiled code, also good for Kotlin.
+        fun recordLumenDetails(
+            filePath: String,
+            fileName: String,
+            lineNumber: Int,
+            targetFunctionName: String,
+            // Potentially add more Lumen fields here as they become available/testable
+            // e.g., callSiteHash: String, className: String?, callingFunctionName: String?
+        ) {
+            val detailString = "Lumen: filePath='$filePath', fileName='$fileName', lineNumber=$lineNumber, targetFunctionName='$targetFunctionName'"
+            capturedLumenData.add(detailString)
+            println("Captured from test code: $detailString") // For live logging during tests
+        }
+    }
+
+    // Test for FQN-based targeting of Kotlin functions
+    @Test
+    fun `kotlin FQN targeted function should receive Lumen object`() {
+        // Test logic for FQN will be added here (Step 6.b)
+        assertTrue(true, "Placeholder for FQN test")
+    }
+
+    // Test for Annotation-based targeting of Kotlin functions
+    @Test
+    fun `kotlin @LumosMaxima annotated function should receive Lumen object`() {
+        // Test logic for annotation will be added here (Step 6.c)
+        assertTrue(true, "Placeholder for Annotation test")
+    }
+
+    // Helper function to configure and run a Kotlin compilation
+    private fun compileAndRun(
+        sourceFiles: List<SourceFile>,
+        fqnTargets: List<String> = emptyList(),
+        useAnnotations: Boolean = false, // Flag to indicate if annotation processing should be implicitly active
+        mainClass: String,
+        mainMethod: String = "main"
+    ): KotlinCompilation.Result {
+        val compilation = KotlinCompilation().apply {
+            sources = sourceFiles
+            compilerPlugins = listOf(com.lumos.plugin.LumosCompilerPluginRegistrar()) // Register our plugin
+            // For FQN targeting, pass options to the plugin
+            if (fqnTargets.isNotEmpty()) {
+                pluginOptions = fqnTargets.map { "plugin:com.lumos.plugin:fqn=$it" }
+            }
+            // For annotation targeting, the plugin should pick it up automatically if configured to do so.
+            // No specific option might be needed here if LumosFunctionPatcherExtension handles annotations.
+
+            inheritClassPath = true // Important for accessing runtime libraries like Lumen itself
+            messageOutputStream = System.out // To see compiler messages
+            verbose = true // For more detailed output
+        }
+
+        val result = compilation.compile()
+
+        if (result.exitCode == KotlinCompilation.ExitCode.OK) {
+            try {
+                val kClazz = result.classLoader.loadClass(mainClass)
+                val mainMethod = kClazz.getMethod(mainMethod) // Assuming a static main method without args
+                mainMethod.invoke(null) // Invoke static main
+            } catch (e: Exception) {
+                throw RuntimeException("Failed to execute compiled code", e)
+            }
+        }
+        return result
+    }
+}


### PR DESCRIPTION
This commit includes:
1. Setup for lumos-examples:
   - Kotlin/Java example classes.
   - build.gradle.kts configuration for lumos-plugin and FQNs.
   - Main.kt for execution.

2. FQN Configuration Propagation Fix:
   - LumosCliOptions: Defines CLI arguments for FQNs.
   - LumosGradleSubplugin: Reads from LumosGradleExtension, passes FQNs as compiler options. Registered via service loader.
   - LumosCompilerPluginRegistrar: Updated to consume these options from CompilerConfiguration and provide them to FIR extensions.

3. Test Infrastructure Setup:
   - lumos-tests/build.gradle.kts: Added kotlin-compile-testing, lumos-plugin, and lumos-runtime dependencies.
   - Created test directory structure.
   - LumosKotlinCompileTest.kt: Initial setup with JUnit, data capture utilities, and a compileAndRun helper.

Blocked:
I could not proceed to implement the actual Kotlin FQN integration test due to a persistent syntax error when attempting to use the multiline string for the test code. This prevented me from implementing the test method.

Next steps would be to resolve this issue and then implement the Kotlin FQN and annotation tests, followed by Java tests and documentation.